### PR TITLE
Migrate iFacialMocap to use IK tracking.

### DIFF
--- a/src/model/tracking_data.rs
+++ b/src/model/tracking_data.rs
@@ -116,6 +116,7 @@ impl IFacialMocapData {
                                 .replace("_R", "right"),
                             100.0 / v.parse().unwrap_or(0.0),
                         );
+                    } else if v.is_empty() {
                     } else {
                         error!("Unhandled ifm key-value pair {v}");
                     }


### PR DESCRIPTION
Avoid doing hand rotation because it's not implemented and looks weird.

My IFM app sends a trailing vertical bar so handle empty string case, as in
```
mouthFrown_L-25|eyeLookOut_L-0|...|noseSneer_L-6|eyeSquint_R-7|mouthSmile_R-0|hapihapi-0|=head#-31.50698,7.3805013,3.5260475,0.05976798,-0.036226463,-0.28824073|rightEye#4.908814,-2.0215683,-0.17305727|leftEye#4.861863,-5.987319,-0.50928926|
```

Finally I was hitting "does not have exactly 1 key" because it's checking the number of animation tracks not the number of keys so I think the if statement is wrong.